### PR TITLE
Add RFC 9039 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  [push, pull_request]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -cover -v ./...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# device-identifiers
-Go packages for processing different kind of device identifiers
+# Device Identifiers
+
+Go packages for processing different kind of device identifiers.
+
+Currently supported device identifiers types:
+- [RFC 9039](https://www.rfc-editor.org/info/rfc9039) - dev:urn device identifiers
+
+# Releases
+
+Intent is to share improvements promptly. If you feel that release is pending feel free to remind on issue tracker.
+
+# New device identifiers
+
+If there exists a standard or RFC specification that you think could be useful feel free to suggest in the issue tracker.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/RisingEdgeSolutions/device-identifiers
+
+go 1.21
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rfc9039/rfc9039.go
+++ b/rfc9039/rfc9039.go
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package rfc9039 provides tools for parsing RFC 9039 specified urn:dev strings.
+package rfc9039
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+const UrnDevPrefix = "urn:dev:"
+
+const UrnDevMaxSectionCount = 16
+
+const SubTypeRegEx = "^[a-z][0-9a-z]*$"
+const DevUrnReservedNoDashRegEx = "^[A-Za-z0-9\\.]+$"
+const DevUrnReservedRegEx = "^[A-Za-z0-9\\.\\-]+$"
+const HexStringRegEx = "^([0-9a-f][0-9a-f])+$"
+const PosNumberRegEx = "^[1-9][0-9]*$"
+
+// UrnDev captures Parse output for urn:dev into own fields.
+type UrnDev struct {
+	// FullName is the full formed urn:dev string.
+	FullName string
+	// Subtype defines what type of urn:dev is specified. Examples for subtypes are "mac", "ow", "org", "os", "ops" and also any valid future types.
+	Subtype string
+	// Organization captures value of organization for Subtype "org", "os" and "ops".
+	Organization string
+	// Product captures value of product for Subtype "ops".
+	Product string
+	// Serial captures value of serial number for Subtype "os" and "ops".
+	Serial string
+	// Component captures all components.
+	Component []string
+	// Identifier captures all identifiers.
+	Identifier []string
+	// Eui64Identifier captures value of mac address for Subtype "mac".
+	Eui64Identifier string
+	// OwIdentifier captures value of 1-wire address for Subtype "ow"
+	OwIdentifier string
+}
+
+// HasUrnDevPrefix can be used to determine whether urn:dev prefix is present, and it would be suitable for parsing with Parse.
+func HasUrnDevPrefix(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), UrnDevPrefix)
+}
+
+func isValidEui64(name string) bool {
+	if len(name) != 16 {
+		return false
+	}
+
+	match, _ := regexp.MatchString(HexStringRegEx, name)
+
+	return match
+}
+
+func isValidOwAddress(name string) bool {
+	if len(name) != 16 {
+		return false
+	}
+
+	match, _ := regexp.MatchString(HexStringRegEx, name)
+
+	return match
+}
+
+func isValidPosNumber(name string) bool {
+	match, _ := regexp.MatchString(PosNumberRegEx, name)
+
+	return match
+}
+
+func isValidIdentifier(name string) bool {
+	match, _ := regexp.MatchString(DevUrnReservedRegEx, name)
+
+	return match
+}
+
+func isValidIdentifierNoDash(name string) bool {
+	match, _ := regexp.MatchString(DevUrnReservedNoDashRegEx, name)
+
+	return match
+}
+
+func isValidSubType(name string) bool {
+	match, _ := regexp.MatchString(SubTypeRegEx, name)
+
+	return match
+}
+
+// Parse parses RFC 9039 specified urn:dev into its components. If incorrectly formed urn:dev string is given as input an error is returned.
+func Parse(name string) (UrnDev, error) {
+	// From: RFC 9039 - Uniform Resource Names for Device Identifiers
+	//
+	// 3.2.  Syntax
+	//
+	//   The identifier is expressed in ASCII characters and has a
+	//   hierarchical structure as follows:
+	//
+	//   devurn = "urn:dev:" body componentpart
+	//   body = macbody / owbody / orgbody / osbody / opsbody / otherbody
+	//   macbody = %s"mac:" hexstring
+	//   owbody = %s"ow:" hexstring
+	//   orgbody = %s"org:" posnumber "-" identifier *( ":" identifier )
+	//   osbody = %s"os:" posnumber "-" serial *( ":" identifier )
+	//   opsbody = %s"ops:" posnumber "-" product "-" serial
+	//             *( ":" identifier )
+	//   otherbody = subtype ":" identifier *( ":" identifier )
+	//   subtype = LALPHA *(DIGIT / LALPHA)
+	//   identifier = 1*devunreserved
+	//   identifiernodash = 1*devunreservednodash
+	//   product = identifiernodash
+	//   serial = identifier
+	//   componentpart = *( "_" identifier )
+	//   devunreservednodash = ALPHA / DIGIT / "."
+	//   devunreserved = devunreservednodash / "-"
+	//   hexstring = 1*(hexdigit hexdigit)
+	//   hexdigit = DIGIT / "a" / "b" / "c" / "d" / "e" / "f"
+	//   posnumber = NZDIGIT *DIGIT
+	//   ALPHA =  %x41-5A / %x61-7A
+	//   LALPHA =  %x41-5A
+	//   NZDIGIT = %x31-39
+	//   DIGIT =  %x30-39
+
+	out := UrnDev{}
+
+	out.FullName = name
+
+	sections := strings.Split(name, ":")
+
+	if len(sections) < 4 || len(sections) >= UrnDevMaxSectionCount {
+		return UrnDev{}, errors.New("invalid input")
+	}
+
+	// urn needs to be normalized for comparison
+	if strings.ToLower(sections[0]) != "urn" {
+		return UrnDev{}, errors.New("invalid input (missing urn)")
+	}
+
+	// dev needs to be normalized for comparison
+	if strings.ToLower(sections[1]) != "dev" {
+		return UrnDev{}, errors.New("invalid input (missing dev)")
+	}
+
+	out.Subtype = sections[2]
+
+	var componentPart = strings.Split(sections[len(sections)-1], "_")
+
+	if len(componentPart) > 1 {
+		// Remove the processed component part
+		sections[len(sections)-1] = componentPart[0]
+
+		out.Component = componentPart[1:]
+		for _, component := range out.Component {
+			if !isValidIdentifier(component) {
+				return UrnDev{}, errors.New("invalid input (componentpart)")
+			}
+		}
+	} else {
+		out.Component = []string{}
+	}
+
+	out.Identifier = sections[3:]
+	for _, identifier := range out.Identifier {
+		if !isValidIdentifier(identifier) {
+			return UrnDev{}, errors.New("invalid input (identifier)")
+		}
+	}
+
+	switch out.Subtype {
+	case "mac":
+		if len(sections) == 5 {
+			return UrnDev{}, errors.New("invalid input (mac)")
+		}
+
+		out.Identifier = out.Identifier[1:]
+		out.Eui64Identifier = sections[3]
+
+		if !isValidEui64(out.Eui64Identifier) {
+			return UrnDev{}, errors.New("invalid input (EUI-64)")
+		}
+
+	case "ow":
+		if len(sections) == 5 {
+			return UrnDev{}, errors.New("invalid input (ow)")
+		}
+
+		out.Identifier = out.Identifier[1:]
+		out.OwIdentifier = sections[3]
+
+		if !isValidOwAddress(out.OwIdentifier) {
+			return UrnDev{}, errors.New("invalid input (ow)")
+		}
+
+	case "org":
+		org := strings.SplitN(sections[3], "-", 2)
+
+		if len(org) != 2 {
+			return UrnDev{}, errors.New("invalid input (org)")
+		}
+
+		out.Organization = org[0]
+		if !isValidPosNumber(out.Organization) {
+			return UrnDev{}, errors.New("invalid input (org)")
+		}
+
+		if !isValidIdentifier(org[1]) {
+			return UrnDev{}, errors.New("invalid input (org)")
+		}
+
+		// Inject organization part's identifier into identifier index 0
+		out.Identifier[0] = org[1]
+
+	case "os":
+		out.Identifier = out.Identifier[1:]
+		os := strings.SplitN(sections[3], "-", 2)
+
+		if len(os) != 2 {
+			return UrnDev{}, errors.New("invalid input (os)")
+		}
+
+		out.Organization = os[0]
+		if !isValidPosNumber(out.Organization) {
+			return UrnDev{}, errors.New("invalid input (os)")
+		}
+
+		out.Serial = os[1]
+		if !isValidIdentifier(out.Serial) {
+			return UrnDev{}, errors.New("invalid input (os)")
+		}
+
+	case "ops":
+		out.Identifier = out.Identifier[1:]
+		ops := strings.Split(sections[3], "-")
+
+		if len(ops) != 3 {
+			return UrnDev{}, errors.New("invalid input (ops)")
+		}
+
+		out.Organization = ops[0]
+		if !isValidPosNumber(out.Organization) {
+			return UrnDev{}, errors.New("invalid input (ops)")
+		}
+		out.Product = ops[1]
+		if !isValidIdentifierNoDash(out.Product) {
+			return UrnDev{}, errors.New("invalid input (ops)")
+		}
+		out.Serial = ops[2]
+		if !isValidIdentifier(out.Serial) {
+			return UrnDev{}, errors.New("invalid input (ops)")
+		}
+
+	default:
+		// otherbody
+		if !isValidSubType(out.Subtype) {
+			return UrnDev{}, errors.New("invalid sub type (" + out.Subtype + ")")
+		}
+	}
+
+	return out, nil
+}

--- a/rfc9039/rfc9039_test.go
+++ b/rfc9039/rfc9039_test.go
@@ -1,0 +1,692 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package rfc9039
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func ExampleHasUrnDevPrefix() {
+	fmt.Println(HasUrnDevPrefix("urn:dev:ops:32473-Refrigerator-5002"))
+	fmt.Println(HasUrnDevPrefix("urn:not-dev:value"))
+	// Output: true
+	// false
+}
+
+func ExampleParse() {
+	devUrn, _ := Parse("urn:dev:ops:32473-Refrigerator-5002")
+	fmt.Println(devUrn.Organization)
+	fmt.Println(devUrn.Product)
+	fmt.Println(devUrn.Serial)
+	// Output: 32473
+	// Refrigerator
+	// 5002
+}
+
+func assertEmptyUrnDevStruct(t *testing.T, value UrnDev) {
+	assert.Equal(t, "", value.FullName)
+	assert.Equal(t, "", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string(nil), value.Component)
+	assert.Equal(t, []string(nil), value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestIsUrnDev(t *testing.T) {
+	assert.True(t, HasUrnDevPrefix("urn:dev:mac:0024beffff804ff1"))
+	assert.True(t, HasUrnDevPrefix("URN:DEV:mac:0024beffff804ff1"))
+	assert.False(t, HasUrnDevPrefix("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6"))
+}
+
+func TestUrnDevInvalidNoSubtype(t *testing.T) {
+	value, err := Parse("urn:dev:")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevInvalidMissingUrn(t *testing.T) {
+	value, err := Parse("foo:dev:mac:0024beffff804ff1")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevInvalidMissingDev(t *testing.T) {
+	value, err := Parse("urn:foo:mac:0024beffff804ff1")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevInvalidComponent(t *testing.T) {
+	value, err := Parse("urn:dev:mac:0024beffff804ff1_fa%il")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevInvalidIdentifier(t *testing.T) {
+	value, err := Parse("urn:dev:mac:0024beffff804ff1:fa%il")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevMac(t *testing.T) {
+	value, err := Parse("urn:dev:mac:0024beffff804ff1")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:mac:0024beffff804ff1", value.FullName)
+	assert.Equal(t, "mac", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "0024beffff804ff1", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevMac2(t *testing.T) {
+	value, err := Parse("urn:dev:mac:0024befffe804ff1")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:mac:0024befffe804ff1", value.FullName)
+	assert.Equal(t, "mac", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "0024befffe804ff1", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevMac3(t *testing.T) {
+	value, err := Parse("urn:dev:mac:acde48234567019f")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:mac:acde48234567019f", value.FullName)
+	assert.Equal(t, "mac", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "acde48234567019f", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevMacInvalidIdentifier(t *testing.T) {
+	value, err := Parse("urn:dev:mac:acde48234567019f:invalid")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevMacInvalidTooShort(t *testing.T) {
+	value, err := Parse("urn:dev:mac:acde48234567019")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevMacInvalidTooLong(t *testing.T) {
+	value, err := Parse("urn:dev:mac:acde48234567019fa")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevMacInvalidCharacters(t *testing.T) {
+	value, err := Parse("urn:dev:mac:acdefail4567019f")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevMacNoValue(t *testing.T) {
+	value, err := Parse("urn:dev:mac")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+func TestUrnDevMacInvalidValue(t *testing.T) {
+	value, err := Parse("urn:dev:mac:")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOw(t *testing.T) {
+	value, err := Parse("urn:dev:ow:10e2073a01080063")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ow:10e2073a01080063", value.FullName)
+	assert.Equal(t, "ow", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "10e2073a01080063", value.OwIdentifier)
+}
+
+func TestUrnDevOw2(t *testing.T) {
+	value, err := Parse("urn:dev:ow:264437f5000000ed_humidity")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ow:264437f5000000ed_humidity", value.FullName)
+	assert.Equal(t, "ow", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{"humidity"}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "264437f5000000ed", value.OwIdentifier)
+}
+
+func TestUrnDevOw3(t *testing.T) {
+	value, err := Parse("urn:dev:ow:264437f5000000ed_temperature")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ow:264437f5000000ed_temperature", value.FullName)
+	assert.Equal(t, "ow", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{"temperature"}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "264437f5000000ed", value.OwIdentifier)
+}
+
+func TestUrnDevOwInvalidIdentifier(t *testing.T) {
+	value, err := Parse("urn:dev:ow:264437f5000000ed:invalid_humidity")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOwInvalidIdentifier2(t *testing.T) {
+	value, err := Parse("urn:dev:ow:10e2073a01080063:invalid")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOwInvalidTooShort(t *testing.T) {
+	value, err := Parse("urn:dev:ow:10e2073a0108006")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOwInvalidTooLong(t *testing.T) {
+	value, err := Parse("urn:dev:ow:10e2073a01080063a")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOwInvalidCharacters(t *testing.T) {
+	value, err := Parse("urn:dev:ow:10e20fail1080063")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOrg(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473-foo")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:org:32473-foo", value.FullName)
+	assert.Equal(t, "org", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{"foo"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOrgWithComponent(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473-foo_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:org:32473-foo_component", value.FullName)
+	assert.Equal(t, "org", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{"foo"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOrgWithMultipleIdentifiers(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473-foo:bar:zoo")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:org:32473-foo:bar:zoo", value.FullName)
+	assert.Equal(t, "org", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{"foo", "bar", "zoo"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+func TestUrnDevOrgInvalidOrg(t *testing.T) {
+	value, err := Parse("urn:dev:org:032473-foo")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOrgInvalidOrgCharacters(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473fail-foo")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOrgInvalidNoDashes(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOrgInvalidNoIdentifier(t *testing.T) {
+	value, err := Parse("urn:dev:org:32473-")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOs(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-123456")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-123456", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "123456", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsWithComponent(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-123456_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-123456_component", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "123456", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsWithIdentifierAndComponent(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-123456:identifier_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-123456:identifier_component", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "123456", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{"identifier"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsSerialWithDashes(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-12-34-56")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-12-34-56", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "12-34-56", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsSerialWithDashesWithComponent(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-12-34-56_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-12-34-56_component", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "12-34-56", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsSerialWithDashesWithIdentrifierAndComponent(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-12-34-56:identifier_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:os:32473-12-34-56:identifier_component", value.FullName)
+	assert.Equal(t, "os", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "12-34-56", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{"identifier"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOsInvalidOrg(t *testing.T) {
+	value, err := Parse("urn:dev:os:032473-12-34-56")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOsInvalidOrgCharacters(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473fail-12-34-56")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOsInvalidNoSerial(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOsInvalidInvalidSerial(t *testing.T) {
+	value, err := Parse("urn:dev:os:32473-")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOps(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator-5002")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ops:32473-Refrigerator-5002", value.FullName)
+	assert.Equal(t, "ops", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "Refrigerator", value.Product)
+	assert.Equal(t, "5002", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOpsWithComponent(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator-5002_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ops:32473-Refrigerator-5002_component", value.FullName)
+	assert.Equal(t, "ops", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "Refrigerator", value.Product)
+	assert.Equal(t, "5002", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOpsWithIdentifier(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator-5002:identifier")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ops:32473-Refrigerator-5002:identifier", value.FullName)
+	assert.Equal(t, "ops", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "Refrigerator", value.Product)
+	assert.Equal(t, "5002", value.Serial)
+	assert.Equal(t, []string{}, value.Component)
+	assert.Equal(t, []string{"identifier"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOpsWithIdentifierAndComponent(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator-5002:identifier_component")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:ops:32473-Refrigerator-5002:identifier_component", value.FullName)
+	assert.Equal(t, "ops", value.Subtype)
+	assert.Equal(t, "32473", value.Organization)
+	assert.Equal(t, "Refrigerator", value.Product)
+	assert.Equal(t, "5002", value.Serial)
+	assert.Equal(t, []string{"component"}, value.Component)
+	assert.Equal(t, []string{"identifier"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevOpsInvalidOrg(t *testing.T) {
+	value, err := Parse("urn:dev:ops:032473-Refrigerator-5002")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOpsInvalidOrgCharacters(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473fail-Refrigerator-5002")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOpsInvalidNoProductAndSerial(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOpsInvalidInvalidProduct(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473--5002")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOpsInvalidNoSerial(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevOpsInvalidInvalidSerial(t *testing.T) {
+	value, err := Parse("urn:dev:ops:32473-Refrigerator-")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}
+
+func TestUrnDevExample(t *testing.T) {
+	value, err := Parse("urn:dev:example:new-1-2-3_comp")
+	if err != nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+	assert.Equal(t, "urn:dev:example:new-1-2-3_comp", value.FullName)
+	assert.Equal(t, "example", value.Subtype)
+	assert.Equal(t, "", value.Organization)
+	assert.Equal(t, "", value.Product)
+	assert.Equal(t, "", value.Serial)
+	assert.Equal(t, []string{"comp"}, value.Component)
+	assert.Equal(t, []string{"new-1-2-3"}, value.Identifier)
+	assert.Equal(t, "", value.Eui64Identifier)
+	assert.Equal(t, "", value.OwIdentifier)
+}
+
+func TestUrnDevInvalidSubType(t *testing.T) {
+	value, err := Parse("urn:dev:INVALID:new-1-2-3_comp")
+	if err == nil {
+		t.Fatalf("Failed to parse")
+		return
+	}
+
+	assertEmptyUrnDevStruct(t, value)
+}


### PR DESCRIPTION
This adds RFC 9039 parsing support for `dev:urn` formatted device identifiers.

Parsed items are available in own `DevUrn` structure.